### PR TITLE
fix: add registry type for tilt

### DIFF
--- a/pkg/ci/pipeline/attributes_test.go
+++ b/pkg/ci/pipeline/attributes_test.go
@@ -30,6 +30,7 @@ func (s *Settings) Merge(other PipelineAttributes) {
 }
 
 func TestParseCISettings(t *testing.T) {
+	t.Parallel()
 	description := "```yaml {ci}\n" + `
 buildAll: true
 pushManifests: true
@@ -48,6 +49,7 @@ values: ["banana", "monkey"]` + "\n```"
 }
 
 func TestParseCISettingsMerge(t *testing.T) {
+	t.Parallel()
 	description1 := "```yaml {ci}\n" + `
 buildAll: true
 pushManifests: false
@@ -76,6 +78,7 @@ values: ["monkey"]` + "\n```"
 }
 
 func TestParseCISettingsError(t *testing.T) {
+	t.Parallel()
 	description := "```yaml {ci}\n" + `
 buildAll: true
 pushManifests: true
@@ -93,6 +96,7 @@ values: ["banana", "monkey"]`
 }
 
 func TestParseCISettingsError2(t *testing.T) {
+	t.Parallel()
 	description := "```yaml {ci}\n" + `
 buildAll: true
 pushMani` + "\n```\n" + `fests: true

--- a/pkg/ci/pipeline/pipeline-type_test.go
+++ b/pkg/ci/pipeline/pipeline-type_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestPipelineTypeUnmarshal(t *testing.T) {
+	t.Parallel()
 	type A struct {
 		PT PipelineType `yaml:"pt"`
 	}
@@ -27,6 +28,7 @@ func TestPipelineTypeUnmarshal(t *testing.T) {
 }
 
 func TestPipelineTypeUnmarshal2(t *testing.T) {
+	t.Parallel()
 	type A struct {
 		PT PipelineType `yaml:"pt"`
 	}

--- a/pkg/ci/pipeline/settings_test.go
+++ b/pkg/ci/pipeline/settings_test.go
@@ -45,6 +45,7 @@ type All struct {
 func (*All) Init() error { return nil }
 
 func TestPipelineSettings(t *testing.T) {
+	t.Parallel()
 	// Marshal
 	all := All{
 		General: PipelineSettings{Type: TagPipeline},

--- a/pkg/common/build-type_test.go
+++ b/pkg/common/build-type_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestBuildTypeUnmarshal(t *testing.T) {
+	t.Parallel()
 	type A struct {
 		BuildType BuildType
 	}

--- a/pkg/common/copy_test.go
+++ b/pkg/common/copy_test.go
@@ -8,6 +8,8 @@ import (
 
 // CopySlice copies a slice.
 func TestCopySlice(t *testing.T) {
+	t.Parallel()
+
 	c := []string{"a", "b"}
 	r := CopySlice(c)
 	c[1] = "c"

--- a/pkg/common/env_type_test.go
+++ b/pkg/common/env_type_test.go
@@ -9,6 +9,7 @@ import (
 )
 
 func TestEnvTypeUnmarshal(t *testing.T) {
+	t.Parallel()
 	type A struct {
 		Env EnvironmentType
 	}

--- a/pkg/common/set/set_test.go
+++ b/pkg/common/set/set_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestUnorderedSetDefault(t *testing.T) {
+	t.Parallel()
 	s := Unordered[int]{}
 	assert.Nil(t, s.set)
 	assert.False(t, s.Exists(10))
@@ -26,6 +27,7 @@ func TestUnorderedSetDefault(t *testing.T) {
 }
 
 func TestUnorderedSetNew(t *testing.T) {
+	t.Parallel()
 	s := NewUnorderedWithCap[int](10)
 	assert.False(t, s.Exists(10))
 	assert.Empty(t, s.set)
@@ -40,6 +42,7 @@ func TestUnorderedSetNew(t *testing.T) {
 }
 
 func TestUnorderedSetInsert(t *testing.T) {
+	t.Parallel()
 	s := NewUnordered(1, 2, 3, 4)
 	assert.True(t, s.Exists(1))
 	assert.True(t, s.Exists(2))
@@ -64,6 +67,7 @@ func TestUnorderedSetInsert(t *testing.T) {
 }
 
 func TestIteration(t *testing.T) {
+	t.Parallel()
 	expect := NewUnordered(1, 4, 9, 16)
 	s := NewUnordered(1, 2, 3, 4)
 

--- a/pkg/common/stack/stack_test.go
+++ b/pkg/common/stack/stack_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestStack(t *testing.T) {
+	t.Parallel()
 	stack := Stack[string]{}
 
 	stack.Push("a")
@@ -31,6 +32,7 @@ func TestStack(t *testing.T) {
 }
 
 func TestStackFrontPop(t *testing.T) {
+	t.Parallel()
 	stack := NewStackWithCap[string](10)
 
 	stack.Push("a")
@@ -55,6 +57,7 @@ func TestStackFrontPop(t *testing.T) {
 }
 
 func TestStackTraverse(t *testing.T) {
+	t.Parallel()
 	stack := NewStackWithCap[string](10)
 	stack.Push("a", "b", "c")
 
@@ -79,6 +82,7 @@ func TestStackTraverse(t *testing.T) {
 }
 
 func TestStackTraverseUpward(t *testing.T) {
+	t.Parallel()
 	stack := NewStackWithCap[string](10)
 	stack.Push("a", "b", "c")
 

--- a/pkg/common/strings/strings_test.go
+++ b/pkg/common/strings/strings_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestSplitLines(t *testing.T) {
+	t.Parallel()
 	s := `a
 b
 c`
@@ -19,6 +20,7 @@ c`
 }
 
 func TestIndent(t *testing.T) {
+	t.Parallel()
 	s := `a
 b
 c`
@@ -31,6 +33,7 @@ c`
 }
 
 func TestSplitAndTrim(t *testing.T) {
+	t.Parallel()
 	s := "a,b,  c, ban nana,d"
 	ls := SplitAndTrim(s, ",")
 	assert.Equal(t, []string{"a", "b", "c", "ban nana", "d"}, ls)

--- a/pkg/component/component-config_test.go
+++ b/pkg/component/component-config_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestComponentsConfig(t *testing.T) {
+	t.Parallel()
 	expected := `
 name: comp1
 version: "1.0.0"
@@ -57,6 +58,7 @@ targets:
 }
 
 func TestComponentsConfigFail(t *testing.T) {
+	t.Parallel()
 	file := `
 name: comp1
 version: "1.a"
@@ -73,6 +75,7 @@ targets:
 }
 
 func TestComponentsConfigFail2(t *testing.T) {
+	t.Parallel()
 	file := `
 name: ""
 version: "1.0.0-rc1+build.1234"
@@ -89,6 +92,7 @@ targets:
 }
 
 func TestComponentsConfigRunnerConfig(t *testing.T) {
+	t.Parallel()
 	file := `
 name: test
 version: "1.0.0"

--- a/pkg/component/input/config_test.go
+++ b/pkg/component/input/config_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestRelativeDir(t *testing.T) {
+	t.Parallel()
 	type Test struct {
 		Path     string
 		Expected string

--- a/pkg/component/query/queries_test.go
+++ b/pkg/component/query/queries_test.go
@@ -82,6 +82,7 @@ func findNames(t *testing.T, comps []*component.Component, names []string) {
 }
 
 func TestComponentFindInside(t *testing.T) {
+	t.Parallel()
 	err := log.Setup("debug")
 	require.NoError(t, err)
 	_, dirs, names := setupFiles(t)
@@ -105,6 +106,7 @@ func TestComponentFindInside(t *testing.T) {
 }
 
 func TestComponentFindByPattern(t *testing.T) {
+	t.Parallel()
 	err := log.Setup("debug")
 	require.NoError(t, err)
 	dir, _, names := setupFiles(t)

--- a/pkg/component/stage/stage_test.go
+++ b/pkg/component/stage/stage_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestStagePriority(t *testing.T) {
+	t.Parallel()
 	stages := NewDefaults()
 
 	assert.True(t, stages[0].IsBefore(stages[1]))

--- a/pkg/dag/execution-order_test.go
+++ b/pkg/dag/execution-order_test.go
@@ -198,6 +198,7 @@ func validate(t *testing.T, comps ...*component.Component) {
 }
 
 func TestGraphExecOrderSimpleFull(t *testing.T) {
+	t.Parallel()
 	err := log.SetLevel("trace")
 	require.NoError(t, err)
 
@@ -252,6 +253,7 @@ func testGenerateCompsFull(
 }
 
 func TestGraphExecOrderSimpleSelection(t *testing.T) {
+	t.Parallel()
 	err := log.SetLevel("trace")
 	require.NoError(t, err)
 
@@ -272,6 +274,7 @@ func TestGraphExecOrderSimpleSelection(t *testing.T) {
 }
 
 func TestGraphExecOrderSimpleSelf(t *testing.T) {
+	t.Parallel()
 	err := log.SetLevel("trace")
 	require.NoError(t, err)
 
@@ -294,6 +297,7 @@ func TestGraphExecOrderSimpleSelf(t *testing.T) {
 }
 
 func TestGraphExecOrderSimpleCycle1(t *testing.T) {
+	t.Parallel()
 	err := log.SetLevel("trace")
 	require.NoError(t, err)
 
@@ -308,6 +312,7 @@ func TestGraphExecOrderSimpleCycle1(t *testing.T) {
 }
 
 func TestGraphExecOrderSimpleCycle2(t *testing.T) {
+	t.Parallel()
 	err := log.SetLevel("trace")
 	require.NoError(t, err)
 
@@ -320,6 +325,7 @@ func TestGraphExecOrderSimpleCycle2(t *testing.T) {
 }
 
 func TestGraphExecOrderSimpleCycle3(t *testing.T) {
+	t.Parallel()
 	// Create a simple graph with 2 components an and a cycle.
 	// 1::image -> 2::lint -> 2::test -> 1::image
 	//          -> 2::build
@@ -367,6 +373,7 @@ func TestGraphExecOrderSimpleCycle3(t *testing.T) {
 }
 
 func TestGraphExecOrderSimpleNoConnection(t *testing.T) {
+	t.Parallel()
 	comps, paths := generateTwoCompsWithNoConnection(t)
 
 	rootDir := "/repo"

--- a/pkg/errors/errors_test.go
+++ b/pkg/errors/errors_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestErrorCombinedHandling(t *testing.T) {
+	t.Parallel()
 	err := errors.New("This is an error.")
 	e := Combine(os.ErrNotExist, err)
 

--- a/pkg/exec/command-ctx_test.go
+++ b/pkg/exec/command-ctx_test.go
@@ -83,6 +83,8 @@ func TestCommandCtxExitCode(t *testing.T) {
 	require.ErrorContains(t, err, "new error here")
 }
 
+// Overwrites stdout, stderr.
+// WARNING: You cannot run the tests in parallel!
 func captureOutput(f func() error) (string, string, error) {
 	origStdout := os.Stdout
 	origStderr := os.Stderr
@@ -94,7 +96,13 @@ func captureOutput(f func() error) (string, string, error) {
 
 	os.Stdout = wStdout
 	os.Stderr = wStderr
+	defer func() {
+		os.Stdout = origStdout
+		os.Stderr = origStderr
+	}()
+
 	err := f()
+
 	os.Stdout = origStdout
 	os.Stderr = origStderr
 	wStdout.Close()

--- a/pkg/exec/env/env_test.go
+++ b/pkg/exec/env/env_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func TestEnvListFind(t *testing.T) {
+	t.Parallel()
 	env := EnvList{"a=fff", "b=ggg"}
 	val := env.FindIdx("a")
 	assert.Equal(t, "fff", val.Value)
@@ -31,6 +32,7 @@ func TestEnvListFind(t *testing.T) {
 }
 
 func TestEnvListFindAll(t *testing.T) {
+	t.Parallel()
 	env := EnvList{"a=  fff", "b=ggg", "c=ttt  ", "dummy"}
 	m := env.FindAll("a", "c", "dummy")
 	assert.Len(t, m, 3)
@@ -46,6 +48,7 @@ func TestEnvListFindAll(t *testing.T) {
 }
 
 func TestEnvMap(t *testing.T) {
+	t.Parallel()
 	env := EnvList{"a=  fff", "b=ggg", "c=ttt  ", "dummy"}
 	m := NewEnvMapFromList(env)
 	assert.Len(t, m, 4)
@@ -57,6 +60,7 @@ func TestEnvMap(t *testing.T) {
 }
 
 func TestEnvMapDup(t *testing.T) {
+	t.Parallel()
 	env := EnvList{"a=  fff", "b=ggg", "c=ttt  ", "a=dummy"}
 	m := NewEnvMapFromList(env)
 	assert.Len(t, m, 3)
@@ -68,6 +72,7 @@ func TestEnvMapDup(t *testing.T) {
 
 //nolint:testifylint // intentional.
 func TestEnvMapDefined(t *testing.T) {
+	t.Parallel()
 	env := EnvList{"a=", "b=ggg", "c=ttt  "}
 	res := env.FindAll("b", "c")
 	assert.NoError(t, res.AssertDefined())
@@ -83,6 +88,7 @@ func TestEnvMapDefined(t *testing.T) {
 }
 
 func TestEnvListFilter(t *testing.T) {
+	t.Parallel()
 	env := EnvList{"a=", "b=ggg", "c==ttt  "}
 	res := env.Remove("a", "c")
 	assert.Len(t, res, 1)

--- a/pkg/exec/git/commands_test.go
+++ b/pkg/exec/git/commands_test.go
@@ -63,6 +63,7 @@ func setupGitRepoWithServer(t *testing.T) (repoCtx Context, serverCtx Context) {
 }
 
 func TestGetChanges(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 	d := gitx.Cwd()
 
@@ -127,6 +128,7 @@ func TestGetChanges(t *testing.T) {
 }
 
 func TestIsIgnored(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 	d := gitx.Cwd()
 
@@ -157,6 +159,7 @@ func TestIsIgnored(t *testing.T) {
 }
 
 func TestGetTags(t *testing.T) {
+	t.Parallel()
 	repoCtx, _ := setupGitRepoWithServer(t)
 
 	e := repoCtx.Chain().
@@ -185,6 +188,7 @@ func TestGetTags(t *testing.T) {
 }
 
 func TestGetChangesRevs(t *testing.T) {
+	t.Parallel()
 	repoCtx := setupGitRepo(t)
 	d := repoCtx.Cwd()
 
@@ -204,6 +208,7 @@ func TestGetChangesRevs(t *testing.T) {
 }
 
 func TestCommitIsAMerge(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 
 	e := gitx.Chain().
@@ -229,6 +234,7 @@ func TestCommitIsAMerge(t *testing.T) {
 }
 
 func TestCommitContainsTag(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 	res, e := gitx.CommitIsAMerge("HEAD")
 	require.NoError(t, e)
@@ -253,6 +259,7 @@ func TestCommitContainsTag(t *testing.T) {
 }
 
 func TestIsRefAHeadOf(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 
 	ahead, count, err := gitx.IsRefAheadOf("HEAD~1", "HEAD")
@@ -272,6 +279,7 @@ func TestIsRefAHeadOf(t *testing.T) {
 }
 
 func TestIsRefReachable(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 
 	reachable, err := gitx.IsRefReachable("HEAD", "HEAD~1")
@@ -284,6 +292,7 @@ func TestIsRefReachable(t *testing.T) {
 }
 
 func TestFetchUntil(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 
 	lastCommit, err := gitx.CurrentRev()
@@ -321,6 +330,7 @@ func TestFetchUntil(t *testing.T) {
 }
 
 func TestLocalRefExists(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 
 	shaExpect, e := gitx.CurrentRev()
@@ -331,6 +341,7 @@ func TestLocalRefExists(t *testing.T) {
 }
 
 func TestCurrentRef(t *testing.T) {
+	t.Parallel()
 	gitx := setupGitRepo(t)
 	ref, e := gitx.CurrentRef()
 	require.NoError(t, e)

--- a/pkg/exec/nix/attr-paths_test.go
+++ b/pkg/exec/nix/attr-paths_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestFlakeInstallable(t *testing.T) {
+	t.Parallel()
 	assert.Equal(t, "./#banana", FlakeInstallable("", "banana"))
 	assert.Equal(t, "./test/bla#banana", FlakeInstallable("test/bla", "banana"))
 	assert.Equal(t, "./test/bla#banana", FlakeInstallable("./test/bla", "banana"))

--- a/pkg/exec/process-compose/compose_test.go
+++ b/pkg/exec/process-compose/compose_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestProcessComposeDevenv(t *testing.T) {
+	t.Parallel()
 	d := t.TempDir()
 	err := fs.CopyFileOrDir("./test/flake.nix", path.Join(d, "flake.nix"), true)
 	require.NoError(t, err)

--- a/pkg/exec/shell/cmd_test.go
+++ b/pkg/exec/shell/cmd_test.go
@@ -7,6 +7,7 @@ import (
 )
 
 func TestCmdString(t *testing.T) {
+	t.Parallel()
 	type D struct {
 		expect string
 		input  []string
@@ -27,6 +28,7 @@ func TestCmdString(t *testing.T) {
 }
 
 func TestCmdStringF(t *testing.T) {
+	t.Parallel()
 	type D struct {
 		expect string
 		input  []string

--- a/pkg/filesystem/paths_test.go
+++ b/pkg/filesystem/paths_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestPathExists(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	assert.True(t, Exists(dir))
 	assert.False(t, Exists(path.Join(dir, "asdf")))
@@ -24,6 +25,7 @@ func TestPathExists(t *testing.T) {
 }
 
 func TestPathExistsLinks(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	dir2 := t.TempDir()
 
@@ -39,6 +41,7 @@ func TestPathExistsLinks(t *testing.T) {
 }
 
 func TestMakeAbs(t *testing.T) {
+	t.Parallel()
 	dir := t.TempDir()
 	d := path.Join(dir, "a/b/c")
 	err := os.MkdirAll(d, DefaultPermissionsDir)

--- a/pkg/image/image-type_test.go
+++ b/pkg/image/image-type_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestImageTypeUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	type A struct {
 		ImgType ImageType
 	}

--- a/pkg/image/images.go
+++ b/pkg/image/images.go
@@ -25,7 +25,6 @@ func NewImageRef(
 	registryType registry.Type,
 	isRelease bool,
 ) (ImageRef, error) {
-
 	if registryType == registry.RegistryTempTilt {
 		ref := os.Getenv("EXPECTED_REF")
 		if ref == "" {

--- a/pkg/image/images_test.go
+++ b/pkg/image/images_test.go
@@ -1,0 +1,60 @@
+package image
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/hashicorp/go-version"
+	"github.com/sdsc-ordes/quitsh/pkg/exec/git"
+	"github.com/sdsc-ordes/quitsh/pkg/registry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImageRef(t *testing.T) {
+	gitx := git.NewCtx("")
+
+	v, e := version.NewVersion("1.0.1")
+	require.NoError(t, e)
+
+	commitSHA, e := gitx.Get("rev-parse", "--short=12", "HEAD")
+	require.NoError(t, e)
+
+	type D struct {
+		b     string
+		p     string
+		r     registry.Type
+		isRel bool
+	}
+
+	os.Setenv("EXPECTED_REF", "tilt-chosen:tag")
+	defer os.Unsetenv("EXPECTED_REF")
+
+	tests := []D{
+		{b: "a/b/c", p: "mypkg", r: registry.RegistryRelease, isRel: true},
+		{b: "a/b/c", p: "mypkg", r: registry.RegistryRelease, isRel: false},
+		{b: "a/b/c", p: "mypkg", r: registry.RegistryTemp, isRel: true},
+		{b: "a/b/c", p: "mypkg", r: registry.RegistryTemp, isRel: false},
+		{b: "a/b/c", p: "mypkg", r: registry.RegistryTempTilt, isRel: true},
+		{b: "a/b/c", p: "mypkg", r: registry.RegistryTempTilt, isRel: false},
+	}
+
+	for _, te := range tests {
+		ref, e := NewImageRef(gitx, te.b, te.p, v, te.r, te.isRel)
+		require.NoError(t, e)
+
+		if te.r == registry.RegistryTempTilt {
+			assert.Equal(t, "tilt-chosen:tag", ref.String())
+
+			continue
+		}
+
+		tag := v.String()
+		if !te.isRel {
+			tag += "-" + commitSHA
+		}
+
+		assert.Equal(t, fmt.Sprintf("%s-%s/%s:%s", te.b, te.r.String(), te.p, tag), ref.String())
+	}
+}

--- a/pkg/image/images_test.go
+++ b/pkg/image/images_test.go
@@ -28,7 +28,7 @@ func TestImageRef(t *testing.T) {
 		isRel bool
 	}
 
-	os.Setenv("EXPECTED_REF", "tilt-chosen:tag")
+	t.Setenv("EXPECTED_REF", "tilt-chosen:tag")
 	defer os.Unsetenv("EXPECTED_REF")
 
 	tests := []D{
@@ -41,7 +41,7 @@ func TestImageRef(t *testing.T) {
 	}
 
 	for _, te := range tests {
-		ref, e := NewImageRef(gitx, te.b, te.p, v, te.r, te.isRel)
+		ref, e := NewImageRef(gitx, te.b, te.p, v, te.r, te.isRel) //nolint:govet //intentional
 		require.NoError(t, e)
 
 		if te.r == registry.RegistryTempTilt {

--- a/pkg/image/names_test.go
+++ b/pkg/image/names_test.go
@@ -15,6 +15,8 @@ type TestData struct {
 }
 
 func TestImageName(t *testing.T) {
+	t.Parallel()
+
 	tests := []TestData{
 		{Name: "bla.com/a/b/c/d", Tag: "1.2.3", Valid: true},
 		{

--- a/pkg/registry/registry-type.go
+++ b/pkg/registry/registry-type.go
@@ -28,7 +28,7 @@ func NewRegistryType(s string) (Type, error) {
 		return RegistryTempTilt, nil
 	}
 
-	return 0, fmt.Errorf("wrong build type '%s'", s)
+	return 0, fmt.Errorf("wrong registry type '%s'", s)
 }
 
 // Implement the pflags Value interface.

--- a/pkg/registry/registry-type.go
+++ b/pkg/registry/registry-type.go
@@ -4,58 +4,66 @@ import (
 	"fmt"
 )
 
-type RegistryType int
+type Type int
 
 const (
 	// If you change this here -> adjust the `New*` functions.
-	RegistryTemp        RegistryType = 0
-	RegistryRelease     RegistryType = 1
-	RegistryTempName                 = "temporary"
-	RegistryReleaseName              = "release"
+	RegistryTemp     Type = 0
+	RegistryRelease  Type = 1
+	RegistryTempTilt Type = 2
+
+	RegistryTempName    = "temporary"
+	RegistryReleaseName = "release"
+
+	RegistryTiltName = "tilt"
 )
 
-func NewRegistryType(s string) (RegistryType, error) {
+func NewRegistryType(s string) (Type, error) {
 	switch s {
 	case RegistryReleaseName:
 		return RegistryRelease, nil
 	case RegistryTempName:
 		return RegistryTemp, nil
+	case RegistryTiltName:
+		return RegistryTempTilt, nil
 	}
 
 	return 0, fmt.Errorf("wrong build type '%s'", s)
 }
 
 // Implement the pflags Value interface.
-func (v RegistryType) String() string {
+func (v Type) String() string {
 	switch v {
 	case RegistryRelease:
 		return RegistryReleaseName
 	case RegistryTemp:
 		return RegistryTempName
+	case RegistryTempTilt:
+		return RegistryTiltName
 	}
 
 	panic("Not implemented.")
 }
 
 // Implement the pflags Value interface.
-func (v *RegistryType) Set(s string) (err error) {
+func (v *Type) Set(s string) (err error) {
 	*v, err = NewRegistryType(s)
 
 	return
 }
 
 // GetAllRegistryTypes returns all registry types.
-func GetAllRegistryTypes() []RegistryType {
-	return []RegistryType{RegistryTemp, RegistryRelease}
+func GetAllRegistryTypes() []Type {
+	return []Type{RegistryTemp, RegistryRelease, RegistryTempTilt}
 }
 
 // Implement the pflags Value interface.
-func (v *RegistryType) Type() string {
+func (v *Type) Type() string {
 	return "string"
 }
 
 // UnmarshalYAML unmarshals from YAML.
-func (v *RegistryType) UnmarshalYAML(unmarshal func(any) error) (err error) {
+func (v *Type) UnmarshalYAML(unmarshal func(any) error) (err error) {
 	var s string
 	err = unmarshal(&s)
 	if err != nil {
@@ -69,6 +77,6 @@ func (v *RegistryType) UnmarshalYAML(unmarshal func(any) error) (err error) {
 
 // MarshalYAML marshals to YAML.
 // Note: needs to be value-receiver to be called!
-func (v RegistryType) MarshalYAML() (any, error) {
+func (v Type) MarshalYAML() (any, error) {
 	return v.String(), nil
 }


### PR DESCRIPTION
## Proposed Changes

-  Add registry type `RegistryTilt` which will compute the image ref from `tilt` env. vars.

## Types of Changes

What types of changes does your contribution introduce? _Put an `x` in the boxes
that apply_

- [ ] A **bug fix** (non-breaking change which fixes an issue). Use MR tag
      `bugfix`.
- [x] A new **feature** (non-breaking change which adds functionality). Use MR
      tag `feature`.
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected). Use MR tag `feature`.
- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply). Use MR tag `chore`.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/quitsh/tree/main/CONTRIBUTING.md)
      guidelines.

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->
