### PR TITLE
fix: launch process-compose over shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@
 
 > [!CAUTION]
 >
-> This repository is in `beta`. The design space of
-> this tool is still explored and breaking changes might occure. 
-> Documentation is incomplete.
+> This repository is in `beta`. The design space of this tool is still explored
+> and breaking changes might occure. Documentation is incomplete.
 
 The `quitsh` framework (`/kwɪʧ/`) is a build-tooling **CLI framework** designed
 to replace loosely-typed scripting languages (e.g., `bash`, `python`, and

--- a/pkg/exec/process-compose/compose.go
+++ b/pkg/exec/process-compose/compose.go
@@ -96,10 +96,9 @@ func StartFromInstallable(
 		)
 	}
 	logFile := path.Join(dir, "process-compose.log")
-
-	b := exec.NewCmdCtxBuilder().
+	b := nix.NewDevShellCtxBuilderI(rootDir, devShellInstallable).
 		Cwd(rootDir).
-		BaseCmd(procCompExe).
+		BaseArgs(procCompExe).
 		BaseArgs("--unix-socket", socketPath).
 		Build()
 

--- a/pkg/exec/process-compose/test/flake.lock
+++ b/pkg/exec/process-compose/test/flake.lock
@@ -39,19 +39,20 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": [
-          "nixpkgsDevenv"
+          "nixpkgs-devenv"
         ]
       },
       "locked": {
-        "lastModified": 1751553093,
-        "narHash": "sha256-QZCfPdqqnX5VQXyAx22d5XubWauJsRevw9KiK/8aHT0=",
+        "lastModified": 1754418859,
+        "narHash": "sha256-6fnM9o5RIG3OtuBF0yhQMECtqzc5pXAc1uSkVaffy58=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "69b825f20e5ef307a43c329fcd7262118d71e5a3",
+        "rev": "e13cd53579f6a0f441ac09230178dccb3008dd36",
         "type": "github"
       },
       "original": {
         "owner": "cachix",
+        "ref": "main",
         "repo": "devenv",
         "type": "github"
       }
@@ -119,10 +120,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749636823,
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -141,6 +143,7 @@
       },
       "locked": {
         "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
@@ -163,7 +166,10 @@
           "devenv",
           "git-hooks"
         ],
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
         "nixpkgs-23-11": [
           "devenv"
         ],
@@ -172,11 +178,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750955511,
-        "narHash": "sha256-IDB/oh/P63ZTdhgSkey2LZHzeNhCdoKk+4j7AaPe1SE=",
+        "lastModified": 1752773918,
+        "narHash": "sha256-dOi/M6yNeuJlj88exI+7k154z+hAhFcuB8tZktiW7rg=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "afa41b08df4f67b8d77a8034b037ac28c71c77df",
+        "rev": "031c3cf42d2e9391eee373507d8c12e0f9606779",
         "type": "github"
       },
       "original": {
@@ -187,38 +193,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgsDevenv": {
-      "locked": {
-        "lastModified": 1750441195,
-        "narHash": "sha256-yke+pm+MdgRb6c0dPt8MgDhv7fcBbdjmv1ZceNTyzKg=",
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "0ceffe312871b443929ff3006960d29b120dc627",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1751271578,
         "narHash": "sha256-P/SQmKDu06x8yv7i0s8bvnnuJYkxVGBWLWHaU+tt4YY=",
@@ -234,12 +208,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-devenv": {
+      "locked": {
+        "lastModified": 1753719760,
+        "narHash": "sha256-GG9WAqR1BWNNBHONF4jQtkwPNQt5EK/zERl5Tbc8Bqk=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "0f871fffdc0e5852ec25af99ea5f09ca7be9b632",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "devenv-root": "devenv-root",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgsDevenv": "nixpkgsDevenv"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-devenv": "nixpkgs-devenv"
       }
     }
   },

--- a/pkg/exec/process-compose/test/flake.nix
+++ b/pkg/exec/process-compose/test/flake.nix
@@ -11,13 +11,13 @@
 
     # The devenv module to create good development shells.
     devenv = {
-      url = "github:cachix/devenv";
-      inputs.nixpkgs.follows = "nixpkgsDevenv";
+      url = "github:cachix/devenv/main";
+      inputs.nixpkgs.follows = "nixpkgs-devenv";
     };
     # We have to lock somehow the pkgs in `mkShell` here:
     # https://github.com/cachix/devenv/issues/1797
     # `nixpkgs` is used in the devShell modules.
-    nixpkgsDevenv.url = "github:cachix/devenv-nixpkgs/rolling";
+    nixpkgs-devenv.url = "github:cachix/devenv-nixpkgs/rolling";
     devenv-root = {
       url = "file+file:///dev/null";
       flake = false;
@@ -25,7 +25,7 @@
 
   };
   outputs =
-    { nixpkgs, devenv, ... }@inputs:
+    { nixpkgs, ... }@inputs:
     let
       inherit (nixpkgs) lib;
 

--- a/tools/nix/flake.lock
+++ b/tools/nix/flake.lock
@@ -39,15 +39,15 @@
         "git-hooks": "git-hooks",
         "nix": "nix",
         "nixpkgs": [
-          "nixpkgsDevenv"
+          "nixpkgs-devenv"
         ]
       },
       "locked": {
-        "lastModified": 1751047748,
-        "narHash": "sha256-KaS77WfbcLkLdqzeWP7GMgU5LltjOyjVxSzRhZbxPCc=",
+        "lastModified": 1754418859,
+        "narHash": "sha256-6fnM9o5RIG3OtuBF0yhQMECtqzc5pXAc1uSkVaffy58=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "0350732a6725a550e4d2d69070774480dce86620",
+        "rev": "e13cd53579f6a0f441ac09230178dccb3008dd36",
         "type": "github"
       },
       "original": {
@@ -173,10 +173,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1749636823,
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "623c56286de5a3193aa38891a6991b28f9bab056",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
         "type": "github"
       },
       "original": {
@@ -195,6 +196,7 @@
       },
       "locked": {
         "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
         "repo": "gitignore.nix",
         "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
@@ -217,7 +219,10 @@
           "devenv",
           "git-hooks"
         ],
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": [
+          "devenv",
+          "nixpkgs"
+        ],
         "nixpkgs-23-11": [
           "devenv"
         ],
@@ -226,11 +231,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750955511,
-        "narHash": "sha256-IDB/oh/P63ZTdhgSkey2LZHzeNhCdoKk+4j7AaPe1SE=",
+        "lastModified": 1752773918,
+        "narHash": "sha256-dOi/M6yNeuJlj88exI+7k154z+hAhFcuB8tZktiW7rg=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "afa41b08df4f67b8d77a8034b037ac28c71c77df",
+        "rev": "031c3cf42d2e9391eee373507d8c12e0f9606779",
         "type": "github"
       },
       "original": {
@@ -241,38 +246,6 @@
       }
     },
     "nixpkgs": {
-      "locked": {
-        "lastModified": 1747179050,
-        "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "adaa24fbf46737f3f1b5497bf64bae750f82942e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgsDevenv": {
-      "locked": {
-        "lastModified": 1750441195,
-        "narHash": "sha256-yke+pm+MdgRb6c0dPt8MgDhv7fcBbdjmv1ZceNTyzKg=",
-        "owner": "cachix",
-        "repo": "devenv-nixpkgs",
-        "rev": "0ceffe312871b443929ff3006960d29b120dc627",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "ref": "rolling",
-        "repo": "devenv-nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
       "locked": {
         "lastModified": 1751011381,
         "narHash": "sha256-krGXKxvkBhnrSC/kGBmg5MyupUUT5R6IBCLEzx9jhMM=",
@@ -288,12 +261,28 @@
         "type": "github"
       }
     },
+    "nixpkgs-devenv": {
+      "locked": {
+        "lastModified": 1753719760,
+        "narHash": "sha256-GG9WAqR1BWNNBHONF4jQtkwPNQt5EK/zERl5Tbc8Bqk=",
+        "owner": "cachix",
+        "repo": "devenv-nixpkgs",
+        "rev": "0f871fffdc0e5852ec25af99ea5f09ca7be9b632",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "ref": "rolling",
+        "repo": "devenv-nixpkgs",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "devenv-root": "devenv-root",
-        "nixpkgs": "nixpkgs_2",
-        "nixpkgsDevenv": "nixpkgsDevenv",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-devenv": "nixpkgs-devenv",
         "snowfall-lib": "snowfall-lib",
         "treefmt-nix": "treefmt-nix"
       }

--- a/tools/nix/flake.nix
+++ b/tools/nix/flake.nix
@@ -22,12 +22,12 @@
     # The devenv module to create good development shells.
     devenv = {
       url = "github:cachix/devenv/main";
-      inputs.nixpkgs.follows = "nixpkgsDevenv";
+      inputs.nixpkgs.follows = "nixpkgs-devenv";
     };
     # We have to lock somehow the pkgs in `mkShell` here:
     # https://github.com/cachix/devenv/issues/1797
     # `nixpkgs` is used in the devShell modules.
-    nixpkgsDevenv.url = "github:cachix/devenv-nixpkgs/rolling";
+    nixpkgs-devenv.url = "github:cachix/devenv-nixpkgs/rolling";
     devenv-root = {
       url = "file+file:///dev/null";
       flake = false;


### PR DESCRIPTION
- Devenv 1.8.1 does not set the env. variables anymore in the process-compose file. Lunching only works over the shell.

## Proposed Changes

<!--
Describe the big picture of your changes here to communicate to the maintainers
why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

## Types of Changes

What types of changes does your contribution introduce? _Put an `x` in the boxes
that apply_

- [x] A **bug fix** (non-breaking change which fixes an issue). Use MR tag
      `bugfix`.
- [ ] A new **feature** (non-breaking change which adds functionality). Use MR
      tag `feature`.
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected). Use MR tag `feature`.
- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply). Use MR tag `chore`.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/quitsh/tree/main/CONTRIBUTING.md)
      guidelines.

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->
