### PR TITLE
fix: CopySlice must return nil if input is nil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/charmbracelet/log v0.4.2
 	github.com/containers/image/v5 v5.35.0
 	github.com/creasty/defaults v1.8.0
-	github.com/go-playground/assert/v2 v2.2.0
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/go-viper/mapstructure/v2 v2.2.1
 	github.com/goccy/go-yaml v1.19.2

--- a/pkg/common/copy.go
+++ b/pkg/common/copy.go
@@ -1,14 +1,20 @@
 package common
 
-// CopySlice copies a slice.
-func CopySlice[T any](s []T) []T {
-	res := make([]T, 0, len(s))
+import "slices"
 
-	return append(res, s...)
+// CopySlice copies a slice.
+// The new slice stays `nil` if `s` is nil.
+func CopySlice[T any](s []T) []T {
+	return slices.Clone(s)
 }
 
-// CopySlice copies a slice but giving an initial capacity.
+// CopySliceC copies a slice but giving an initial capacity.
+// The new slice stays `nil` if `s` is nil.
 func CopySliceC[T any](s []T, capacity int) []T {
+	if s == nil {
+		return nil
+	}
+
 	res := make([]T, 0, capacity)
 
 	return append(res, s...)

--- a/pkg/common/copy_test.go
+++ b/pkg/common/copy_test.go
@@ -5,22 +5,29 @@ package common
 import (
 	"testing"
 
-	"github.com/go-playground/assert/v2"
+	"github.com/stretchr/testify/assert"
 )
 
 // CopySlice copies a slice.
 func TestCopySlice(t *testing.T) {
 	t.Parallel()
 
-	c := []string{"a", "b"}
+	var c []string
 	r := CopySlice(c)
-	c[1] = "c"
+	assert.Nil(t, r)
 
+	r = CopySliceC(c, 10)
+	assert.Nil(t, r)
+
+	c = []string{"a", "b"}
+	r = CopySlice(c)
+	assert.Len(t, r, 2)
+	c[1] = "c"
 	assert.Equal(t, "b", r[1])
 
 	c = []string{"a", "b"}
 	r = CopySliceC(c, 4)
+	assert.Len(t, r, 2)
 	c[1] = "c"
-
 	assert.Equal(t, "b", r[1])
 }


### PR DESCRIPTION
## Proposed Changes

- Fix bug that `CopySlice`  should return `nil` when `nil` input. Same behavior as `slices.Clone()`.

## Types of Changes

What types of changes does your contribution introduce? _Put an `x` in the boxes
that apply_

- [x] A **bug fix** (non-breaking change which fixes an issue). Use MR tag
      `bugfix`.
- [ ] A new **feature** (non-breaking change which adds functionality). Use MR
      tag `feature`.
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected). Use MR tag `feature`.
- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply). Use MR tag `chore`.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [ ] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/quitsh/tree/main/CONTRIBUTING.md)
      guidelines.

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->
