### PR TITLE
feat: add proc-compose-flake dispatch for process-compose functionality

### DIFF
--- a/pkg/cli/cmd/process-compose/exec/exec.go
+++ b/pkg/cli/cmd/process-compose/exec/exec.go
@@ -20,8 +20,9 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 	var stArgs startArgs
 
 	startCmd := &cobra.Command{
-		Use:     "exec [devenv-attr-path or devenv-installable] [args-to-proc-compose]",
-		Short:   "Exec commands on process-compose on the correct instance.",
+		Use: "exec [attr-path or installable] [args-to-proc-compose]",
+		Short: "Exec process-compose definition from a 'devenv.sh' Nix shell or " +
+			"a 'process-compose-flake' derivation.",
 		PreRunE: cobra.MinimumNArgs(1),
 		RunE: func(_cmd *cobra.Command, args []string) error {
 			stArgs.AttrPath = args[0]

--- a/pkg/cli/cmd/process-compose/exec/exec.go
+++ b/pkg/cli/cmd/process-compose/exec/exec.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/sdsc-ordes/quitsh/pkg/cli"
+	processcomposestart "github.com/sdsc-ordes/quitsh/pkg/cli/cmd/process-compose/start"
 	"github.com/sdsc-ordes/quitsh/pkg/errors"
 	pc "github.com/sdsc-ordes/quitsh/pkg/exec/process-compose"
 	"github.com/sdsc-ordes/quitsh/pkg/log"
@@ -11,10 +12,8 @@ import (
 )
 
 type startArgs struct {
+	processcomposestart.BasicArgs
 	args []string
-
-	attrPath string
-	flakeDir string
 }
 
 func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
@@ -25,7 +24,7 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 		Short:   "Exec commands on process-compose on the correct instance.",
 		PreRunE: cobra.MinimumNArgs(1),
 		RunE: func(_cmd *cobra.Command, args []string) error {
-			stArgs.attrPath = args[0]
+			stArgs.AttrPath = args[0]
 			if len(args) > 1 {
 				stArgs.args = args[1:]
 			}
@@ -33,45 +32,48 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 			_, err := RunExec(
 				log.Global(),
 				cl.RootDir(),
-				stArgs.flakeDir,
-				stArgs.attrPath,
-				stArgs.args)
+				stArgs.FlakeDir,
+				stArgs.AttrPath,
+				pc.ProcessComposeImpl(stArgs.Impl),
+				stArgs.args,
+			)
 
 			return err
 		},
 	}
 
-	startCmd.Flags().
-		StringVarP(&stArgs.flakeDir,
-			"flake-dir", "f", defaultFlakeDir, "The flake directory which contains a 'flake.nix' file.")
+	processcomposestart.DefineBasicArgs(startCmd, &stArgs.BasicArgs, defaultFlakeDir)
 
 	parent.AddCommand(startCmd)
 }
 
 // RunExec runs process-compose commands on the instance
-// defined in `devenvShellAttrPath`.
+// defined in `attrPath`.
 func RunExec(
 	log log.ILog,
 	rootDir string,
 	flakeDir string,
-	devenvShellAttrPath string,
+	attrPath string,
+	impl pc.ProcessComposeImpl,
 	args []string,
 ) (
 	pcCtx *pc.ProcessComposeCtx,
 	err error,
 ) {
-	if strings.Contains(devenvShellAttrPath, "#") {
+	if strings.Contains(attrPath, "#") {
 		pcCtx, err = pc.StartFromInstallable(
 			log,
 			rootDir,
-			devenvShellAttrPath,
+			attrPath,
+			impl,
 			pc.WithMustBeStarted(true))
 	} else {
 		pcCtx, err = pc.Start(
 			log,
 			rootDir,
 			flakeDir,
-			devenvShellAttrPath,
+			attrPath,
+			impl,
 			pc.WithMustBeStarted(true))
 	}
 

--- a/pkg/cli/cmd/process-compose/process-compose.go
+++ b/pkg/cli/cmd/process-compose/process-compose.go
@@ -14,7 +14,7 @@ import (
 func AddCmd(cl cli.ICLI, parent *cobra.Command, flakeDirDefault string) *cobra.Command {
 	configCmd := &cobra.Command{
 		Use:   "process-compose",
-		Short: "Start/stop process-compose services defined in Nix 'devenv.sh' shells.",
+		Short: "Start/stop process-compose services defined in Nix 'devenv.sh' shells or 'service-flakes'.",
 		RunE: func(_cmd *cobra.Command, _args []string) error {
 			return errors.New("no subcommand given")
 		},

--- a/pkg/cli/cmd/process-compose/start/start.go
+++ b/pkg/cli/cmd/process-compose/start/start.go
@@ -121,6 +121,8 @@ func DefineBasicArgs(cmd *cobra.Command, baseArgs *BasicArgs, defaultFlakeDir st
 // startProcessCompose starts the process-compose services from `flake.nix` in `flakeDir`
 // defined in the installable `devenvShellInstallable`.
 // You can wait for the processes names to be running with `waitFor`.
+//
+//nolint:funlen
 func startProcessCompose(
 	rootDir string,
 	flakeDir string,

--- a/pkg/cli/cmd/process-compose/start/start.go
+++ b/pkg/cli/cmd/process-compose/start/start.go
@@ -24,9 +24,14 @@ const timeoutWait = 100 * time.Second
 const timeoutWaitInterval = 100 * time.Millisecond
 
 type (
+	BasicArgs struct {
+		Impl     string
+		AttrPath string
+		FlakeDir string
+	}
+
 	startArgs struct {
-		attrPath       string
-		flakeDir       string
+		BasicArgs
 		socketPathFile string
 
 		waitFor             []string
@@ -47,12 +52,13 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 		Long:    longDesc,
 		PreRunE: cobra.MinimumNArgs(1),
 		RunE: func(_cmd *cobra.Command, args []string) error {
-			stArgs.attrPath = args[0]
+			stArgs.AttrPath = args[0]
 
 			_, err := startProcessCompose(
 				cl.RootDir(),
-				stArgs.flakeDir,
-				stArgs.attrPath,
+				stArgs.FlakeDir,
+				stArgs.AttrPath,
+				pc.ProcessComposeImpl(stArgs.Impl),
 				stArgs.waitFor,
 				stArgs.waitForReady,
 				stArgs.noFailOnCompleted,
@@ -65,9 +71,7 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 		},
 	}
 
-	startCmd.Flags().
-		StringVarP(&stArgs.flakeDir,
-			"flake-dir", "f", defaultFlakeDir, "The flake directory which contains a 'flake.nix' file.")
+	DefineBasicArgs(startCmd, &stArgs.BasicArgs, defaultFlakeDir)
 
 	startCmd.Flags().
 		StringArrayVarP(&stArgs.waitFor,
@@ -102,13 +106,26 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 	parent.AddCommand(startCmd)
 }
 
+func DefineBasicArgs(cmd *cobra.Command, baseArgs *BasicArgs, defaultFlakeDir string) {
+	cmd.Flags().
+		StringVarP(&baseArgs.FlakeDir,
+			"flake-dir", "f", defaultFlakeDir, "The flake directory which contains a 'flake.nix' file.")
+
+	cmd.Flags().
+		StringVarP(&baseArgs.Impl,
+			"impl", "i", string(pc.ProcessComposeOverServicesFlake),
+			"Use `devenv` if the attribute is a `devenv` Nix shell "+
+				"or a `services-flake` if it is a `services-flake`-derivation.")
+}
+
 // startProcessCompose starts the process-compose services from `flake.nix` in `flakeDir`
 // defined in the installable `devenvShellInstallable`.
 // You can wait for the processes names to be running with `waitFor`.
 func startProcessCompose(
 	rootDir string,
 	flakeDir string,
-	devenvShellAttrPath string,
+	attrPath string,
+	impl pc.ProcessComposeImpl,
 	waitForRunning []string,
 	waitForReady []string,
 	noFailOnCompleted []string,
@@ -120,11 +137,12 @@ func startProcessCompose(
 	pcCtx *pc.ProcessComposeCtx,
 	err error,
 ) {
-	if strings.Contains(devenvShellAttrPath, "#") {
+	if strings.Contains(attrPath, "#") {
 		pcCtx, err = pc.StartFromInstallable(
 			log.Global(),
 			rootDir,
-			devenvShellAttrPath,
+			attrPath,
+			impl,
 			pc.WithMustBeStarted(false),
 		)
 	} else {
@@ -132,7 +150,8 @@ func startProcessCompose(
 			log.Global(),
 			rootDir,
 			flakeDir,
-			devenvShellAttrPath,
+			attrPath,
+			impl,
 			pc.WithMustBeStarted(false),
 		)
 	}

--- a/pkg/cli/cmd/process-compose/start/start.go
+++ b/pkg/cli/cmd/process-compose/start/start.go
@@ -16,8 +16,8 @@ import (
 )
 
 const longDesc = `Start a process-compose definition from a 'devenv.sh' Nix shell
-specified by an attribute path (e.g. 'mynamespace.shells.test-dbs') or installable
-(e.g. './tools/nix#mynamespace.shells.test-dbs')
+specified by an attribute path (e.g. 'mynamespace.test-dbs') or installable
+(e.g. './tools/nix#mynamespace.test-dbs')
 in a 'flake.nix' file.`
 
 const timeoutWait = 100 * time.Second
@@ -34,12 +34,11 @@ type (
 		BasicArgs
 		socketPathFile string
 
-		waitFor             []string
-		waitForReady        []string
-		noFailOnCompleted   []string
-		attach              bool
-		timeoutWait         time.Duration
-		timeoutWaitInterval time.Duration
+		waitFor           []string
+		waitForReady      []string
+		noFailOnCompleted []string
+		attach            bool
+		timeoutWait       time.Duration
 	}
 )
 
@@ -64,7 +63,6 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 				stArgs.noFailOnCompleted,
 				stArgs.socketPathFile,
 				stArgs.timeoutWait,
-				stArgs.timeoutWaitInterval,
 				stArgs.attach)
 
 			return err
@@ -99,10 +97,6 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 		DurationVar(&stArgs.timeoutWait,
 			"timeout", timeoutWait, "The max. timeout (e.g. `100s`) for waiting on processes.")
 
-	startCmd.Flags().
-		DurationVar(&stArgs.timeoutWaitInterval,
-			"timeout-interval", timeoutWaitInterval, "The max. timeout interval (e.g. `100ms`) for polling processes.")
-
 	parent.AddCommand(startCmd)
 }
 
@@ -133,7 +127,6 @@ func startProcessCompose(
 	noFailOnCompleted []string,
 	socketPathFile string,
 	timeoutWait time.Duration,
-	timeoutWaitInterval time.Duration,
 	attach bool,
 ) (
 	pcCtx *pc.ProcessComposeCtx,
@@ -160,6 +153,14 @@ func startProcessCompose(
 	if err != nil {
 		return pcCtx, errors.AddContext(err, "could not start process-compose")
 	}
+	defer func() {
+		if err != nil {
+			log.Warn("Stopping due to errors.")
+			e := pcCtx.Stop()
+
+			log.ErrorE(e, "Could not stop process-compose.")
+		}
+	}()
 
 	if socketPathFile != "" {
 		log.Infof("Write socket path file '%s'.", socketPathFile)
@@ -200,8 +201,6 @@ func startProcessCompose(
 			"interval", timeoutWaitInterval)
 	}
 
-	ctx, cancel = context.WithTimeout(ctx, timeoutWaitInterval)
-	defer cancel()
 	fulfilled, err := pcCtx.WaitTill(ctx, log.Global(), conds...)
 	if err != nil {
 		return pcCtx, errors.AddContext(err, "failed to wait for processes")

--- a/pkg/cli/cmd/process-compose/start/start.go
+++ b/pkg/cli/cmd/process-compose/start/start.go
@@ -46,8 +46,9 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 	var stArgs startArgs
 
 	startCmd := &cobra.Command{
-		Use:     "start [devenv-attr-path or devenv-installable]",
-		Short:   "Start a process-compose definition from a 'devenv.sh' Nix shell.",
+		Use: "start [attr-path or installable]",
+		Short: "Start a process-compose definition from a 'devenv.sh' Nix shell or " +
+			"a 'process-compose-flake' derivation.",
 		Long:    longDesc,
 		PreRunE: cobra.MinimumNArgs(1),
 		RunE: func(_cmd *cobra.Command, args []string) error {
@@ -109,7 +110,7 @@ func DefineBasicArgs(cmd *cobra.Command, baseArgs *BasicArgs, defaultFlakeDir st
 		StringVarP(&baseArgs.Impl,
 			"impl", "i", string(pc.ProcessComposeOverServicesFlake),
 			"Use `devenv` if the attribute is a `devenv` Nix shell "+
-				"or a `services-flake` if it is a `services-flake`-derivation.")
+				"or a `process-compose-flake` if it is a `process-compose-flake`-derivation.")
 }
 
 // startProcessCompose starts the process-compose services from `flake.nix` in `flakeDir`

--- a/pkg/cli/cmd/process-compose/stop/stop.go
+++ b/pkg/cli/cmd/process-compose/stop/stop.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/sdsc-ordes/quitsh/pkg/cli"
+	processcomposestart "github.com/sdsc-ordes/quitsh/pkg/cli/cmd/process-compose/start"
 	"github.com/sdsc-ordes/quitsh/pkg/errors"
 	pc "github.com/sdsc-ordes/quitsh/pkg/exec/process-compose"
 	"github.com/sdsc-ordes/quitsh/pkg/log"
@@ -16,51 +17,53 @@ specified by an attribute path (e.g. 'mynamespace.shells.test-dbs') or installab
 in a 'flake.nix' file.`
 
 type startArgs struct {
-	attrPath string
-	flakeDir string
+	processcomposestart.BasicArgs
 }
 
 func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 	var stArgs startArgs
 
-	startCmd := &cobra.Command{
-		Use:     "stop [devenv-attr-path or devenv-installable]",
+	stopCmd := &cobra.Command{
+		Use:     "stop [attr-path to 'devenv' NixShell or 'services-flake' derivation]",
 		Short:   "Stop a process-compose definition from a 'devenv.sh' Nix shell.",
 		Long:    longDesc,
 		PreRunE: cobra.MinimumNArgs(1),
 		RunE: func(_cmd *cobra.Command, args []string) error {
-			stArgs.attrPath = args[0]
+			stArgs.AttrPath = args[0]
 
 			_, err := StopService(
 				cl.RootDir(),
-				stArgs.flakeDir,
-				stArgs.attrPath)
+				stArgs.FlakeDir,
+				stArgs.AttrPath,
+				pc.ProcessComposeImpl(stArgs.Impl),
+			)
 
 			return err
 		},
 	}
 
-	startCmd.Flags().
-		StringVarP(&stArgs.flakeDir,
-			"flake-dir", "f", defaultFlakeDir, "The flake directory which contains a 'flake.nix' file.")
+	processcomposestart.DefineBasicArgs(stopCmd, &stArgs.BasicArgs, defaultFlakeDir)
 
-	parent.AddCommand(startCmd)
+	parent.AddCommand(stopCmd)
 }
 
 // StopService stops the process-compose services from `flake.nix` in `flakeDir`
-// defined in the installable `devenvShellInstallable`.
+// defined in the attribute `attrPath`.
 func StopService(
 	rootDir string,
 	flakeDir string,
-	devenvShellAttrPath string) (
+	attrPath string,
+	impl pc.ProcessComposeImpl,
+) (
 	pcCtx *pc.ProcessComposeCtx,
 	err error,
 ) {
-	if strings.Contains(devenvShellAttrPath, "#") {
+	if strings.Contains(attrPath, "#") {
 		pcCtx, err = pc.StartFromInstallable(
 			log.Global(),
 			rootDir,
-			devenvShellAttrPath,
+			attrPath,
+			impl,
 			pc.WithMustBeStarted(true),
 		)
 	} else {
@@ -68,7 +71,8 @@ func StopService(
 			log.Global(),
 			rootDir,
 			flakeDir,
-			devenvShellAttrPath,
+			attrPath,
+			impl,
 			pc.WithMustBeStarted(true))
 	}
 

--- a/pkg/cli/cmd/process-compose/stop/stop.go
+++ b/pkg/cli/cmd/process-compose/stop/stop.go
@@ -24,7 +24,7 @@ func AddCmd(cl cli.ICLI, parent *cobra.Command, defaultFlakeDir string) {
 	var stArgs startArgs
 
 	stopCmd := &cobra.Command{
-		Use:     "stop [attr-path to 'devenv' NixShell or 'services-flake' derivation]",
+		Use:     "stop [attr-path to 'devenv' NixShell or 'process-compose-flake' derivation]",
 		Short:   "Stop a process-compose definition from a 'devenv.sh' Nix shell.",
 		Long:    longDesc,
 		PreRunE: cobra.MinimumNArgs(1),

--- a/pkg/cli/cmd/process-compose/stop/stop.go
+++ b/pkg/cli/cmd/process-compose/stop/stop.go
@@ -12,8 +12,8 @@ import (
 )
 
 const longDesc = `Stop a process-compose definition from a 'devenv.sh' Nix shell
-specified by an attribute path (e.g. 'mynamespace.shells.test-dbs') or installable
-(e.g. './tools/nix#mynamespace.shells.test-dbs')
+specified by an attribute path (e.g. 'mynamespace.test-dbs') or installable
+(e.g. './tools/nix#mynamespace.test-dbs')
 in a 'flake.nix' file.`
 
 type startArgs struct {

--- a/pkg/exec/process-compose/compose.go
+++ b/pkg/exec/process-compose/compose.go
@@ -25,13 +25,13 @@ const ProcessReady ProcessState = 1
 const ProcessCompleted ProcessState = 2
 
 const ProcessComposeOverDevenv ProcessComposeImpl = "devenv"
-const ProcessComposeOverServicesFlake ProcessComposeImpl = "services-flake"
+const ProcessComposeOverServicesFlake ProcessComposeImpl = "process-compose-flake"
 
 // ProcessComposeCtx represents a `process-compose` context.
 type (
 	// ProcessComposeImpl represents the implementation
 	// if the process-compopse is defined in a `devenv` NixShell or
-	// over `services-flake`.
+	// over `process-compose-flake`.
 	ProcessComposeImpl string
 
 	ProcessComposeCtx struct {
@@ -89,7 +89,7 @@ func Start(
 
 // StartFromInstallable starts the process compose from a Nix
 // `installable` (e.g. `./tools/nix#custodian.shells.test-dbs`
-// which must be a `devenv` shell or a `services-flake` derivation).
+// which must be a `devenv` shell or a `process-compose-flake` derivation).
 // The `rootDir` is the working directory and
 // where the `.devenv/state/pwd` file is for `nonPureEval == false`.
 func StartFromInstallable(
@@ -176,7 +176,7 @@ func settingsFromServicesFlake(
 	log log.ILog,
 	rootDir, installable string,
 ) (*ProcessComposeCtx, *exec.CmdContext, error) {
-	log.Infof("Getting settings for 'services-flake' implementation.")
+	log.Infof("Getting settings for 'process-compose-flake' implementation.")
 
 	// Compute deterministic temp directory base on `procCompExe`.
 	dir := path.Join(os.TempDir(), "process-compose",

--- a/pkg/exec/process-compose/compose.go
+++ b/pkg/exec/process-compose/compose.go
@@ -73,7 +73,7 @@ type (
 // where the `.devenv/state/pwd` file is for `nonPureEval == false`.
 // Note: You also call [StartFromInstallable] and directly pass an
 // installable, e.g. a flake output attribute path like
-// `./a/b/c#mynamespace.shells.test-dbs`.
+// `./a/b/c#mynamespace.test-dbs`.
 func Start(
 	log log.ILog,
 	rootDir string,
@@ -180,7 +180,7 @@ func settingsFromServicesFlake(
 
 	// Compute deterministic temp directory base on `procCompExe`.
 	dir := path.Join(os.TempDir(), "process-compose",
-		"process-compose"+fmt.Sprintf("%x",
+		"process-compose-"+fmt.Sprintf("%x",
 			sha256.Sum256([]byte(installable)))[:6])
 
 	err := os.MkdirAll(dir, fs.DefaultPermissionsDir)
@@ -259,7 +259,7 @@ func settingsFromDevenv(
 
 	// Compute deterministic temp directory base on `installable`.
 	dir := path.Join(os.TempDir(), "process-compose",
-		"process-compose"+fmt.Sprintf("%x",
+		"process-compose-"+fmt.Sprintf("%x",
 			sha256.Sum256([]byte(installable)))[:6])
 
 	err = os.MkdirAll(dir, fs.DefaultPermissionsDir)

--- a/pkg/exec/process-compose/compose.go
+++ b/pkg/exec/process-compose/compose.go
@@ -24,11 +24,22 @@ const ProcessRunning ProcessState = 0
 const ProcessReady ProcessState = 1
 const ProcessCompleted ProcessState = 2
 
+const ProcessComposeOverDevenv ProcessComposeImpl = "devenv"
+const ProcessComposeOverServicesFlake ProcessComposeImpl = "services-flake"
+
 // ProcessComposeCtx represents a `process-compose` context.
 type (
+	// ProcessComposeImpl represents the implementation
+	// if the process-compopse is defined in a `devenv` NixShell or
+	// over `services-flake`.
+	ProcessComposeImpl string
+
 	ProcessComposeCtx struct {
 		exec.CmdContext
-		socket string
+		version string
+		socket  string
+
+		startCmd []string
 
 		tempDir string
 		logFile string
@@ -67,17 +78,18 @@ func Start(
 	log log.ILog,
 	rootDir string,
 	flakeDir string,
-	devShellAttrPath string,
+	attrPath string,
+	impl ProcessComposeImpl,
 	opts ...StartOption,
 ) (pc *ProcessComposeCtx, err error) {
-	devShellAttrPath = nix.FlakeInstallable(flakeDir, devShellAttrPath)
+	attrPath = nix.FlakeInstallable(flakeDir, attrPath)
 
-	return StartFromInstallable(log, rootDir, devShellAttrPath, opts...)
+	return StartFromInstallable(log, rootDir, attrPath, impl, opts...)
 }
 
 // StartFromInstallable starts the process compose from a Nix
-// `devShellInstallable` (e.g. `./tools/nix#custodian.shells.test-dbs`
-// which must be a `devenv` shell).
+// `installable` (e.g. `./tools/nix#custodian.shells.test-dbs`
+// which must be a `devenv` shell or a `services-flake` derivation).
 // The `rootDir` is the working directory and
 // where the `.devenv/state/pwd` file is for `nonPureEval == false`.
 //
@@ -85,76 +97,33 @@ func Start(
 func StartFromInstallable(
 	log log.ILog,
 	rootDir string,
-	devShellInstallable string,
+	installable string,
+	impl ProcessComposeImpl,
 	opts ...StartOption,
 ) (pc *ProcessComposeCtx, err error) {
 	var o startOpts
 	err = o.Apply(opts...)
 	if err != nil {
-		return pc, err
-	}
-
-	procCompExe, socketPath, err := getSocketPath(devShellInstallable, rootDir)
-	if err != nil {
-		return pc, err
-	}
-
-	err = os.MkdirAll(path.Dir(socketPath), fs.DefaultPermissionsDir)
-	if err != nil {
-		return pc, err
-	}
-
-	procCompConfig, err := buildProcComposeConfigFile(devShellInstallable, rootDir)
-	if err != nil {
-		return pc, err
-	}
-
-	// Compute deterministic temp directory base on `procCompExe`.
-	dir := path.Join(os.TempDir(),
-		fmt.Sprintf("process-compose-%x",
-			sha256.Sum256([]byte(procCompConfig))))
-	err = os.MkdirAll(dir, fs.DefaultPermissionsDir)
-	if err != nil {
-		return pc, errors.AddContext(
-			err,
-			"could not create process-compose temp dir (logfile etc.).",
-		)
-	}
-	logFile := path.Join(dir, "process-compose.log")
-
-	// We need to launch the process-compose over a
-	// devShell to start it properly.
-	build := func(b exec.CmdContextBuilder) *exec.CmdContext {
-		return b.
-			Cwd(rootDir).
-			BaseArgs("--unix-socket", socketPath).
-			Build()
-	}
-	pcCtxDev := build(nix.NewDevShellCtxBuilderI(
-		rootDir, devShellInstallable).BaseArgs(procCompExe))
-
-	pcB := exec.NewCmdCtxBuilder().BaseCmd(procCompExe)
-	version, err := pcB.Build().Get("version")
-	if err != nil {
 		return nil, err
 	}
 
-	pc = &ProcessComposeCtx{
-		CmdContext: *build(pcB),
-		log:        log,
-		socket:     socketPath,
-		tempDir:    dir,
-		logFile:    logFile,
+	var pcCtxDev *exec.CmdContext
+
+	switch impl {
+	case ProcessComposeOverDevenv:
+		pc, pcCtxDev, err = settingsFromDevenv(log, rootDir, installable)
+	case ProcessComposeOverServicesFlake:
+		pc, pcCtxDev, err = settingsFromServicesFlake(log, rootDir, installable)
+	default:
+		return nil, errors.New(
+			"Implementation '%v' for process-compose start is not supported.",
+			impl,
+		)
 	}
 
-	log.Info("Settings for process-compose.",
-		"version", version,
-		"rootDir", rootDir,
-		"installable", devShellInstallable,
-		"procCompExe", procCompExe,
-		"config", procCompConfig,
-		"socketPath", socketPath,
-		"logFile", logFile)
+	if err != nil {
+		return nil, errors.AddContext(err, "Could not create process-compose ctx.")
+	}
 
 	// Write the socket path to the file
 	if o.socketPathFile != "" {
@@ -172,42 +141,183 @@ func StartFromInstallable(
 	// Start the process compose.
 	// Attach if the socket path does not exist
 	// (the script already does it)
-	if fs.Exists(socketPath) {
+	if fs.Exists(pc.Socket()) {
 		log.Warnf("Socket '%s' is already existing. "+
-			"Assume process-compose is started.", socketPath)
+			"Assume process-compose is started.", pc.Socket())
 
 		return pc, nil
 	} else {
 		if o.mustBeStarted {
 			return pc, errors.New("The process-compose instance must be started already but "+
-				"socket '%s' is not existing.", socketPath)
+				"socket '%s' is not existing.", pc.Socket())
 		}
 		log.Info("Start process-compose.")
 
-		err = pcCtxDev.Check(
-			"--config", procCompConfig,
-			"--keep-project",
-			"--disable-dotenv",
-			"--log-file", logFile,
-			"--ordered-shutdown",
-			"-D",
-			"up")
+		err = pcCtxDev.Check(pc.startCmd...)
 		if err != nil {
-			return pc, errors.AddContext(err, "Could not start process-compose with '%s'.", procCompConfig)
+			return pc, errors.AddContext(err, "Could not start process-compose with start command '%v'.", pc.startCmd)
 		}
 	}
 
 	log.Info(
-		"Started process-compose for devenv shell.",
-		"shell",
-		devShellInstallable,
+		"Started process-compose.",
+		"impl",
+		impl,
+		"installable",
+		installable,
 		"socket",
-		socketPath,
+		pc.Socket(),
 		"logFile",
-		logFile,
+		pc.LogFile(),
 	)
 
 	return pc, nil
+}
+
+func settingsFromServicesFlake(
+	log log.ILog,
+	rootDir, installable string,
+) (*ProcessComposeCtx, *exec.CmdContext, error) {
+	log.Infof("Getting settings for 'services-flake' implementation.")
+
+	// Compute deterministic temp directory base on `procCompExe`.
+	dir := path.Join(os.TempDir(), "process-compose",
+		"process-compose"+fmt.Sprintf("%x",
+			sha256.Sum256([]byte(installable)))[:6])
+
+	err := os.MkdirAll(dir, fs.DefaultPermissionsDir)
+	if err != nil {
+		return nil, nil, errors.AddContext(
+			err,
+			"could not create process-compose temp dir (logfile etc.).",
+		)
+	}
+	logFile := path.Join(dir, "process-compose.log")
+
+	socketPath := path.Join(dir, "pc.sock")
+
+	startCmd := []string{
+		"--unix-socket", socketPath,
+		"--keep-project",
+		"--disable-dotenv",
+		"--ordered-shutdown",
+		"--log-file", logFile,
+		"--no-server=false",
+		"-D",
+		"up"}
+
+	pc := nix.NewRunCtx(
+		rootDir,
+		func(b exec.CmdContextBuilder) exec.CmdContextBuilder {
+			return b.Cwd(rootDir).BaseArgs(installable, "--",
+				"--unix-socket", socketPath)
+		},
+	)
+
+	version, err := pc.Get("version")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	log.Info("Settings for process-compose.",
+		"version", version,
+		"rootDir", rootDir,
+		"installable", installable,
+		"socketPath", socketPath,
+		"logFile", logFile)
+
+	pcCtx := &ProcessComposeCtx{
+		CmdContext: *pc.CmdContext,
+		version:    version,
+		log:        log,
+		socket:     socketPath,
+		startCmd:   startCmd,
+		tempDir:    dir,
+		logFile:    logFile,
+	}
+
+	return pcCtx, &pcCtx.CmdContext, nil
+}
+
+func settingsFromDevenv(
+	log log.ILog,
+	rootDir, installable string,
+) (*ProcessComposeCtx, *exec.CmdContext, error) {
+	log.Infof("Getting settings for 'devenv' implementation.")
+	procCompExe, socketPath, err := getSocketPath(installable, rootDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = os.MkdirAll(path.Dir(socketPath), fs.DefaultPermissionsDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	procCompConfig, err := buildProcComposeConfigFile(installable, rootDir)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Compute deterministic temp directory base on `installable`.
+	dir := path.Join(os.TempDir(), "process-compose",
+		"process-compose"+fmt.Sprintf("%x",
+			sha256.Sum256([]byte(installable)))[:6])
+
+	err = os.MkdirAll(dir, fs.DefaultPermissionsDir)
+	if err != nil {
+		return nil, nil, errors.AddContext(
+			err,
+			"could not create process-compose temp dir (logfile etc.).",
+		)
+	}
+	logFile := path.Join(dir, "process-compose.log")
+
+	// We need to launch the process-compose over a
+	// devShell to start it properly.
+	build := func(b exec.CmdContextBuilder) *exec.CmdContext {
+		return b.
+			Cwd(rootDir).
+			BaseArgs("--unix-socket", socketPath).
+			Build()
+	}
+	pcCtxDev := build(nix.NewDevShellCtxBuilderI(
+		rootDir, installable).BaseArgs(procCompExe))
+
+	pcB := exec.NewCmdCtxBuilder().BaseCmd(procCompExe)
+	version, err := pcB.Build().Get("version")
+	if err != nil {
+		return nil, nil, err
+	}
+
+	log.Info("Settings for process-compose.",
+		"version", version,
+		"rootDir", rootDir,
+		"installable", installable,
+		"procCompExe", procCompExe,
+		"config", procCompConfig,
+		"socketPath", socketPath,
+		"logFile", logFile)
+
+	startCmd := []string{
+		"--config", procCompConfig,
+		"--keep-project",
+		"--disable-dotenv",
+		"--ordered-shutdown",
+		"--log-file", logFile,
+		"--ordered-shutdown",
+		"-D",
+		"up"}
+
+	return &ProcessComposeCtx{
+		CmdContext: *build(pcB),
+		version:    version,
+		log:        log,
+		socket:     socketPath,
+		startCmd:   startCmd,
+		tempDir:    dir,
+		logFile:    logFile,
+	}, pcCtxDev, nil
 }
 
 // Socket returns the socket used.

--- a/pkg/exec/process-compose/compose.go
+++ b/pkg/exec/process-compose/compose.go
@@ -195,7 +195,6 @@ func settingsFromServicesFlake(
 	socketPath := path.Join(dir, "pc.sock")
 
 	startCmd := []string{
-		"--unix-socket", socketPath,
 		"--keep-project",
 		"--disable-dotenv",
 		"--ordered-shutdown", //nolint:goconst // ok here.

--- a/pkg/exec/process-compose/compose.go
+++ b/pkg/exec/process-compose/compose.go
@@ -92,8 +92,6 @@ func Start(
 // which must be a `devenv` shell or a `services-flake` derivation).
 // The `rootDir` is the working directory and
 // where the `.devenv/state/pwd` file is for `nonPureEval == false`.
-//
-//nolint:funlen
 func StartFromInstallable(
 	log log.ILog,
 	rootDir string,
@@ -200,7 +198,7 @@ func settingsFromServicesFlake(
 		"--unix-socket", socketPath,
 		"--keep-project",
 		"--disable-dotenv",
-		"--ordered-shutdown",
+		"--ordered-shutdown", //nolint:goconst // ok here.
 		"--log-file", logFile,
 		"--no-server=false",
 		"-D",

--- a/pkg/exec/process-compose/compose_test.go
+++ b/pkg/exec/process-compose/compose_test.go
@@ -27,7 +27,8 @@ func TestProcessCompose(t *testing.T) {
 		socketPathFile := path.Join("./test", ".pc-socket-path")
 
 		pcCtx, err := Start(logger, d, d,
-			"mynamespace.shells.test",
+			"mynamespace.shells.test-devenv",
+			ProcessComposeOverDevenv,
 			WithSocketPathFile(socketPathFile),
 		)
 		require.NoError(t, err)
@@ -69,7 +70,8 @@ func TestProcessCompose(t *testing.T) {
 		require.NoError(t, err)
 
 		pcCtx, err := Start(logger,
-			d, d, "mynamespace.shells.test",
+			d, d, "mynamespace.shells.test-devenv",
+			ProcessComposeOverDevenv,
 			WithMustBeStarted(false))
 		require.NoError(t, err)
 		defer func() {
@@ -91,5 +93,46 @@ func TestProcessCompose(t *testing.T) {
 		)
 		require.NoError(t, err)
 		assert.False(t, fulfilled)
+	})
+}
+
+func TestProcessComposeServicesFlake(t *testing.T) {
+	t.Run("Normal", func(t *testing.T) {
+		d := t.TempDir()
+		logger := log.NewLogger("test")
+		err := fs.CopyFileOrDir("./test/flake.nix", path.Join(d, "flake.nix"), true)
+		require.NoError(t, err)
+		err = fs.CopyFileOrDir("./test/flake.lock", path.Join(d, "flake.lock"), true)
+		require.NoError(t, err)
+
+		socketPathFile := path.Join("./test", ".pc-socket-path")
+
+		pcCtx, err := Start(logger, d, d,
+			"mynamespace.shells.test-services-flake",
+			ProcessComposeOverServicesFlake,
+			WithSocketPathFile(socketPathFile),
+		)
+		require.NoError(t, err)
+
+		defer func() {
+			log, e := os.ReadFile(pcCtx.LogFile())
+			require.NoError(t, e)
+			t.Log("Process Compose Log:\n", string(log))
+
+			e = pcCtx.Stop()
+			require.NoError(t, e)
+		}()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+
+		fulfilled, err := pcCtx.WaitTill(
+			ctx,
+			logger,
+			ProcessCond{Name: "mailhog", State: ProcessReady, NoFailOnCompleted: false},
+		)
+		require.NoError(t, err)
+		assert.True(t, fulfilled)
+		assert.FileExists(t, socketPathFile)
 	})
 }

--- a/pkg/exec/process-compose/compose_test.go
+++ b/pkg/exec/process-compose/compose_test.go
@@ -27,7 +27,7 @@ func TestProcessCompose(t *testing.T) {
 		socketPathFile := path.Join("./test", ".pc-socket-path")
 
 		pcCtx, err := Start(logger, d, d,
-			"mynamespace.shells.test-devenv",
+			"mynamespace.test-devenv",
 			ProcessComposeOverDevenv,
 			WithSocketPathFile(socketPathFile),
 		)
@@ -70,7 +70,7 @@ func TestProcessCompose(t *testing.T) {
 		require.NoError(t, err)
 
 		pcCtx, err := Start(logger,
-			d, d, "mynamespace.shells.test-devenv",
+			d, d, "mynamespace.test-devenv",
 			ProcessComposeOverDevenv,
 			WithMustBeStarted(false))
 		require.NoError(t, err)
@@ -108,7 +108,7 @@ func TestProcessComposeServicesFlake(t *testing.T) {
 		socketPathFile := path.Join("./test", ".pc-socket-path")
 
 		pcCtx, err := Start(logger, d, d,
-			"mynamespace.shells.test-services-flake",
+			"mynamespace.test-services-flake",
 			ProcessComposeOverServicesFlake,
 			WithSocketPathFile(socketPathFile),
 		)

--- a/pkg/exec/process-compose/compose_test.go
+++ b/pkg/exec/process-compose/compose_test.go
@@ -108,7 +108,7 @@ func TestProcessComposeServicesFlake(t *testing.T) {
 		socketPathFile := path.Join("./test", ".pc-socket-path")
 
 		pcCtx, err := Start(logger, d, d,
-			"mynamespace.test-services-flake",
+			"mynamespace.test-process-compose-flake",
 			ProcessComposeOverServicesFlake,
 			WithSocketPathFile(socketPathFile),
 		)

--- a/pkg/exec/process-compose/test/flake.lock
+++ b/pkg/exec/process-compose/test/flake.lock
@@ -893,12 +893,29 @@
         "type": "github"
       }
     },
+    "process-compose-flake": {
+      "locked": {
+        "lastModified": 1782060835,
+        "narHash": "sha256-Q8HH2t1l3MITtWCWY4ytcH5F/Q7aAHo3Iq/QTMAKTe0=",
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "rev": "464ff6880737f063c3f0d3d2c7781fda9190868f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Platonic-Systems",
+        "repo": "process-compose-flake",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "devenv": "devenv",
         "devenv-root": "devenv-root",
         "nixpkgs": "nixpkgs_6",
-        "nixpkgs-devenv": "nixpkgs-devenv"
+        "nixpkgs-devenv": "nixpkgs-devenv",
+        "process-compose-flake": "process-compose-flake",
+        "services-flake": "services-flake"
       }
     },
     "rust-overlay": {
@@ -919,6 +936,21 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "services-flake": {
+      "locked": {
+        "lastModified": 1784799366,
+        "narHash": "sha256-aK4fmqmGbk0J2sUhex79NAZTd1002DNWNsfubO6aic0=",
+        "owner": "juspay",
+        "repo": "services-flake",
+        "rev": "eed1ab55413afbb8fd7bc929076c73894e5104e0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "juspay",
+        "repo": "services-flake",
         "type": "github"
       }
     },

--- a/pkg/exec/process-compose/test/flake.nix
+++ b/pkg/exec/process-compose/test/flake.nix
@@ -23,6 +23,9 @@
       url = "file+file:///dev/null";
       flake = false;
     };
+
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+    services-flake.url = "github:juspay/services-flake";
   };
 
   outputs =
@@ -53,7 +56,14 @@
             pkgs = loadNixpgs system;
             lib = pkgs.lib;
           in
-          func { inherit lib pkgs system; }
+          func {
+            inherit
+              inputs
+              lib
+              pkgs
+              system
+              ;
+          }
         );
 
       # Define a devShell for testing with mongodb service.
@@ -106,14 +116,30 @@
       devShells = forAllSystems (
         { pkgs, ... }:
         {
-          test = makeShell pkgs;
+          test-devenv = makeShell pkgs;
         }
       );
 
       legacyPackages = forAllSystems (
         { pkgs, ... }:
+        let
+          servicesMod = (import inputs.process-compose-flake.lib { inherit pkgs; }).evalModules {
+            modules = [
+              inputs.services-flake.processComposeModules.default
+              {
+                services.mailhog."mailhog" = {
+                  enable = true;
+                  smtp.port = 9999;
+                  ui.port = 9998;
+                };
+              }
+            ];
+          };
+        in
         {
-          mynamespace.shells.test = makeShell pkgs;
+          mynamespace.shells.test-devenv = makeShell pkgs;
+          mynamespace.shells.test-services-flake = servicesMod.config.outputs.package;
+          mynamespace.shells.test-services-flake-config = servicesMod.config;
         }
       );
     };

--- a/pkg/exec/process-compose/test/flake.nix
+++ b/pkg/exec/process-compose/test/flake.nix
@@ -137,9 +137,9 @@
           };
         in
         {
-          mynamespace.shells.test-devenv = makeShell pkgs;
-          mynamespace.shells.test-services-flake = servicesMod.config.outputs.package;
-          mynamespace.shells.test-services-flake-config = servicesMod.config;
+          mynamespace.test-devenv = makeShell pkgs;
+          mynamespace.test-services-flake = servicesMod.config.outputs.package;
+          mynamespace.test-services-flake-config = servicesMod.config;
         }
       );
     };

--- a/pkg/exec/process-compose/test/flake.nix
+++ b/pkg/exec/process-compose/test/flake.nix
@@ -138,8 +138,8 @@
         in
         {
           mynamespace.test-devenv = makeShell pkgs;
-          mynamespace.test-services-flake = servicesMod.config.outputs.package;
-          mynamespace.test-services-flake-config = servicesMod.config;
+          mynamespace.test-process-compose-flake = servicesMod.config.outputs.package;
+          mynamespace.test-process-compose-flake-config = servicesMod.config;
         }
       );
     };

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -315,49 +315,62 @@ func TestCLIExecTarget2Arg(t *testing.T) {
 }
 
 func TestCLIProcessCompose(t *testing.T) {
-	_, rootDir, err := git.NewCtxAtRoot(".")
-	require.NoError(t, err)
+	test := func(t *testing.T, impl string, waitFor string) {
+		_, rootDir, err := git.NewCtxAtRoot(".")
+		require.NoError(t, err)
 
-	cwd := path.Join(rootDir, "pkg/exec/process-compose/test")
-	cli := setup(t).Cwd(cwd).BaseArgs("--root-dir", cwd).Build()
+		cwd := path.Join(rootDir, "pkg/exec/process-compose/test")
+		cli := setup(t).Cwd(cwd).BaseArgs("--root-dir", cwd).Build()
 
-	_, stderr, err := cli.GetStdErr(
-		"--root-dir", ".",
-		"--log-level",
-		"debug",
-		"process-compose",
-		"start",
-		"--flake-dir", ".",
-		"--wait-for", "httpbin",
-		"mynamespace.shells.test",
-	)
-	require.NoError(t, err, "Stderr:\n"+stderr)
-	assert.Contains(t, stderr, "Inspect processes with")
-	assert.Contains(t, stderr, "Stop processes with")
-
-	stdout, _, err := cli.GetStdErr(
-		"--root-dir", ".",
-		"--log-level",
-		"debug",
-		"process-compose",
-		"exec",
-		"--flake-dir", ".",
-		"mynamespace.shells.test",
-		"list",
-	)
-	require.NoError(t, err, "Process compose list failed")
-	assert.Contains(t, stdout, "httpbin")
-
-	defer func() {
-		_, _, err := cli.GetStdErr(
+		_, stderr, err := cli.GetStdErr(
 			"--root-dir", ".",
 			"--log-level",
 			"debug",
 			"process-compose",
-			"stop",
+			"start",
 			"--flake-dir", ".",
-			"mynamespace.shells.test",
+			"--impl", impl,
+			"--wait-for", waitFor,
+			"mynamespace.test-"+impl,
 		)
-		require.NoError(t, err, "Could not stop process-compose.")
-	}()
+		require.NoError(t, err, "Stderr:\n"+stderr)
+		assert.Contains(t, stderr, "Inspect processes with")
+		assert.Contains(t, stderr, "Stop processes with")
+
+		stdout, _, err := cli.GetStdErr(
+			"--root-dir", ".",
+			"--log-level",
+			"debug",
+			"process-compose",
+			"exec",
+			"--flake-dir", ".",
+			"--impl", impl,
+			"mynamespace.test-"+impl,
+			"list",
+		)
+		require.NoError(t, err, "Process compose list failed")
+		assert.Contains(t, stdout, waitFor)
+
+		defer func() {
+			_, _, err := cli.GetStdErr(
+				"--root-dir", ".",
+				"--log-level",
+				"debug",
+				"process-compose",
+				"stop",
+				"--impl", impl,
+				"--flake-dir", ".",
+				"mynamespace.test-"+impl,
+			)
+			require.NoError(t, err, "Could not stop process-compose.")
+		}()
+	}
+
+	t.Run("devenv", func(t *testing.T) {
+		test(t, "devenv", "httpbin")
+	})
+
+	t.Run("services-flake", func(t *testing.T) {
+		test(t, "services-flake", "mailhog")
+	})
 }

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -370,7 +370,7 @@ func TestCLIProcessCompose(t *testing.T) {
 		test(t, "devenv", "httpbin")
 	})
 
-	t.Run("services-flake", func(t *testing.T) {
-		test(t, "services-flake", "mailhog")
+	t.Run("process-compose-flake", func(t *testing.T) {
+		test(t, "process-compose-flake", "mailhog")
 	})
 }

--- a/tools/nix/shells/shells.nix
+++ b/tools/nix/shells/shells.nix
@@ -54,6 +54,10 @@ let
 
           quitsh.languages.go.enable = true;
           quitsh.toolchains = [ "ci" ];
+
+          # Disable all process-compose stuff.
+          # Set to native manager to not have PC_ env. variables.
+          process.manager.implementation = "native";
         }
       ]
       ++ build-go;


### PR DESCRIPTION
## Proposed Changes

- Simple dispatch to also make `services-flake` process-compose setup work which should be the default.

## Types of Changes

What types of changes does your contribution introduce? _Put an `x` in the boxes
that apply_

- [ ] A **bug fix** (non-breaking change which fixes an issue). Use MR tag
      `bugfix`.
- [x] A new **feature** (non-breaking change which adds functionality). Use MR
      tag `feature`.
- [ ] A **breaking change** (fix or feature that would cause existing
      functionality to not work as expected). Use MR tag `feature`.
- [ ] A **non-productive** update (documentation, tooling, etc. if none of the
      other choices apply). Use MR tag `chore`.

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating
the PR. If you're unsure about any of them, don't hesitate to ask. We're here to
help! This is simply a reminder of what we are going to look for before merging
your code._

- [x] I have read the
      [CONTRIBUTING](https://github.com/sdsc-ordes/quitsh/tree/main/CONTRIBUTING.md)
      guidelines.

## Further Comments

<!-- If this is a relatively large or complex change, kick off the discussion by -->
<!-- explaining why you chose the solution you did and what alternatives you -->
<!-- considered, etc... -->
